### PR TITLE
Feat: Implementar métricas por estaciones con query SQL

### DIFF
--- a/Frontend/src/app/components/metrics/metric-estaciones/metric-estaciones.component.html
+++ b/Frontend/src/app/components/metrics/metric-estaciones/metric-estaciones.component.html
@@ -1,1 +1,8 @@
-<p>metric-estaciones works!</p>
+<div style="display: block; height: 300px;">
+  <canvas
+    baseChart
+    [type]="'doughnut'"
+    [data]="doughnutChartData"
+    [options]="chartOptions">
+  </canvas>
+</div>

--- a/Frontend/src/app/components/metrics/metric-estaciones/metric-estaciones.component.ts
+++ b/Frontend/src/app/components/metrics/metric-estaciones/metric-estaciones.component.ts
@@ -1,11 +1,87 @@
 import { Component } from '@angular/core';
+import { ChartData, ChartOptions, ChartType } from 'chart.js';
+import { RecipeService } from '../../../services/recipe.service';
+import { RecipeEstacionPorcentaje } from '../../../models/recipes';
 
 @Component({
   selector: 'app-metric-estaciones',
   standalone: false,
   templateUrl: './metric-estaciones.component.html',
-  styleUrl: './metric-estaciones.component.css'
+  styleUrl: './metric-estaciones.component.css',
 })
 export class MetricEstacionesComponent {
+  public doughnutChartType: ChartType = 'doughnut';
 
+  public doughnutChartData: ChartData<`doughnut`> = {
+    labels: ['Primavera', 'Verano', 'Invierno', 'Otoño', 'todo el año'],
+    datasets: [
+      {
+        data: [],
+        backgroundColor: [
+          '#42A5F5',
+          '#66BB6A',
+          '#FFA726',
+          '#EF5350',
+          '#AB47BC',
+        ],
+      },
+    ],
+  };
+
+  public chartOptions: ChartOptions<'doughnut'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      tooltip: {
+        callbacks: {
+          label: (tooltipItem) => {
+            const dataset =
+              this.doughnutChartData.datasets[tooltipItem.datasetIndex!];
+            const value = dataset.data[tooltipItem.dataIndex!];
+            const label =
+              this.doughnutChartData.labels![tooltipItem.dataIndex!] || '';
+            return `${label}: ${value}%`;
+          },
+        },
+      },
+    },
+  };
+
+  constructor(private recipeService: RecipeService) {}
+
+  ngOnInit(): void {
+    this.recipeService
+      .getEstacionesPorcentaje()
+      .subscribe((data: RecipeEstacionPorcentaje[]) => {
+        const categoriaMap = new Map<string, number>();
+        data.forEach((item) => {
+          categoriaMap.set(
+            item.estacion.toLowerCase(),
+            Number(item.porcentaje)
+          );
+        });
+
+        this.doughnutChartData = {
+          labels: ['Primavera', 'Verano', 'Invierno', 'Otoño', 'todo el año'],
+          datasets: [
+            {
+              data: [
+                categoriaMap.get('primavera') || 0,
+                categoriaMap.get('verano') || 0,
+                categoriaMap.get('invierno') || 0,
+                categoriaMap.get('otoño') || 0,
+                categoriaMap.get('todo el año') || 0,
+              ],
+              backgroundColor: [
+                '#42A5F5',
+                '#66BB6A',
+                '#FFA726',
+                '#EF5350',
+                '#AB47BC',
+              ],
+            },
+          ],
+        };
+      });
+  }
 }

--- a/Frontend/src/app/services/recipe.service.ts
+++ b/Frontend/src/app/services/recipe.service.ts
@@ -7,6 +7,7 @@ import {
   RecipeViewDetail,
   RecipeArray,
   RecipeCategoriaPorcentaje,
+  RecipeEstacionPorcentaje,
 } from '../models/recipes';
 
 @Injectable({
@@ -79,5 +80,10 @@ export class RecipeService {
 
   getRecipePorcentajes(): Observable<RecipeCategoriaPorcentaje[]> {
     return this.http.get<RecipeCategoriaPorcentaje[]>(`${this.api}/porcentajes`);
+  }
+
+  getEstacionesPorcentaje():Observable<RecipeEstacionPorcentaje[]>{
+
+    return this.http.get<RecipeEstacionPorcentaje[]>(`${this.api}/porcentajesEstacion`)
   }
 }


### PR DESCRIPTION
## Cambios realizados:
- ✅ Nueva query SQL para obtener porcentajes por estación
- ✅ Manejo de valores NULL como "Todo el año" usando CASE WHEN
- ✅ Servicio `getEstacionesPorcentaje()` en RecipeService
- ✅ Componente MetricEstacionesComponent con gráfico de dona
- ✅ Interfaz RecipeEstacionPorcentaje

## Características:
- 🌸 Primavera, ☀️ Verano, 🍂 Otoño, ❄️ Invierno, 🗓️ Todo el año
- Gráfico interactivo con tooltips
- Query optimizada con ORDER BY para orden lógico

## Testing:
- ✅ Query probada en Postman
- ✅ Componente renderiza correctamente
- ✅ Tooltips funcionan en todas las secciones